### PR TITLE
HI-106 magerun version control

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,10 +1,5 @@
 ---
 
-magento_version: 1
-
-magerun1_url: https://files.magerun.net/n98-magerun.phar
-magerun2_url: https://files.magerun.net/n98-magerun2.phar
-
-magerun_use_latest: true
-
+magento_version: 2
+magerun_version: 3.0.5
 magerun_path: /usr/local/bin/magerun

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -2,7 +2,7 @@
 
 - name: Download magerun phar file
   get_url:
-    url: "https://files.magerun.net/n98-magerun{{ '2' if magento_version == '2' else '' }}-{{ magerun_version }}.phar"
+    url: "https://files.magerun.net/n98-magerun{{ 2 if magento_version == '2' else '' }}-{{ magerun_version }}.phar"
     dest: /tmp/magerun.phar
     force: yes
 
@@ -16,5 +16,5 @@
 - name: Set permissions on magerun
   become: yes
   file:
-    path: /tmp/magerun.phar
+    path: "{{ magerun_path }}"
     mode: "a+x"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,22 +1,20 @@
 ---
 
-# Get Download URL Based upon Magento version
-- set_fact:
-    download_url: "{{ magerun1_url if magento_version == 1 else magerun2_url }}"
-
 - name: Download magerun phar file
   get_url:
-    url: "{{ download_url }}"
+    url: "https://files.magerun.net/n98-magerun{{ '2' if magento_version == '2' else '' }}-{{ magerun_version }}.phar"
     dest: /tmp/magerun.phar
+    force: yes
 
 - name: "Copy magerun into {{ magerun_path }}"
   become: yes
-  shell: "cp /tmp/magerun.phar {{ magerun_path }}"
-  args:
-    creates: "{{ magerun_path }}"
+  copy:
+    src: /tmp/magerun.phar
+    remote_src: yes
+    dest: "{{ magerun_path }}"
 
 - name: Set permissions on magerun
   become: yes
   file:
-    path: "{{ magerun_path }}"
+    path: /tmp/magerun.phar
     mode: "a+x"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,16 +7,15 @@
   tags:
     - magerun
 
-- include: install.yml
-  when: not magerun_installed.stat.exists
+- name: Ensure correct n98-magerun version
+  command: "{{ magerun_path }} -V"
+  register: magerun_installed_version
+  when: magerun_installed.stat.exists
+  changed_when: false
   tags:
     - magerun
 
-- name: Update n98-magerun if required
-  become: yes
-  command: magerun self-update
-  register: magerun_update
-  changed_when: "'You are using the latest n98-magerun version' in magerun_update.stdout_lines"
-  when: magerun_use_latest
+- include: install.yml
+  when: not magerun_installed.stat.exists or magerun_version not in magerun_installed_version.stdout_lines
   tags:
     - magerun

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,6 +16,6 @@
     - magerun
 
 - include: install.yml
-  when: not magerun_installed.stat.exists or magerun_version not in magerun_installed_version.stdout_lines
+  when: not magerun_installed.stat.exists or magerun_version not in magerun_installed_version.stdout
   tags:
     - magerun


### PR DESCRIPTION
This PR will:

- have the installation check the Magerun version
- change the default Magerun to Magerun2 because we don't plan on supporting any more M1 sites